### PR TITLE
task(main):메인 컴포넌트 리팩토링, 일부 섹션 컴포넌트 분리

### DIFF
--- a/src/domains/main/components/blocks/CurrentTime.tsx
+++ b/src/domains/main/components/blocks/CurrentTime.tsx
@@ -1,0 +1,26 @@
+import { format } from 'date-fns'
+import { useEffect, useState } from 'react'
+
+export const CurrentTime = () => {
+  const [currentTime, setCurrentTime] = useState({
+    today: format(new Date(), 'yyyy/MM/dd'),
+    time: format(new Date(), 'HH:mm:ss'),
+  })
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCurrentTime({
+        today: format(new Date(), 'yyyy/MM/dd'),
+        time: format(new Date(), 'HH:mm:ss'),
+      })
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [])
+
+  return (
+    <div className="getDate">
+      <p className="today">{currentTime.today}</p>
+      <p className="time">{currentTime.time}</p>
+    </div>
+  )
+}

--- a/src/domains/main/components/blocks/RollingBanner.tsx
+++ b/src/domains/main/components/blocks/RollingBanner.tsx
@@ -1,0 +1,32 @@
+type BannerItemType = {
+  text: string
+  icon: string
+}
+
+type RollingBannerPropsType = {
+  items: BannerItemType[]
+  direction: 'left' | 'right'
+}
+
+export const RollingBanner = ({ items, direction }: RollingBannerPropsType) => {
+  return (
+    <div className={`banner_line ${direction}`}>
+      <div className="roller_wrap">
+        {['original', 'clone'].map((el, idx) => (
+          <div
+            key={`rolloer-${el}`}
+            id={`roller${idx + 1}_${el}`}
+            className={`rolling_list ${el}`}
+          >
+            {items.map((item, index) => (
+              <div key={`${direction}-${index}`}>
+                <p>{item.text}</p>
+                <img src={item.icon} alt={`icon${idx}`} />
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/domains/main/components/index.ts
+++ b/src/domains/main/components/index.ts
@@ -1,1 +1,5 @@
-export * from "./pages/Main";
+export * from './pages/Main'
+
+// blocks
+export * from './blocks/CurrentTime'
+export * from './blocks/RollingBanner'

--- a/src/domains/main/components/pages/Main.tsx
+++ b/src/domains/main/components/pages/Main.tsx
@@ -1,116 +1,22 @@
-import React, { useEffect, useState } from 'react'
+import { useState } from 'react'
+import { RollingBanner, CurrentTime } from '@main/components'
+import { bannerItemsList } from '@main/constants'
 
 //--------------- 이미지 ---------------//
 /* sc_hero 키비주얼 영역 */
-// ##1. 상·하단 흐르는 배너
-import icon1 from '@/assets/imgs/main/img_hero_icon1.png'
-import icon2 from '@/assets/imgs/main/img_hero_icon2.png'
-import icon3 from '@/assets/imgs/main/img_hero_icon3.png'
-// ##2. 가운데 콘텐츠
+// ## 가운데 콘텐츠
 import window1 from '@/assets/imgs/main/img_hero_window1.png'
 import window2 from '@/assets/imgs/main/img_hero_window2.png'
 import window3 from '@/assets/imgs/main/img_hero_window3.png'
 
-//--------------- 중복 배너 ---------------//
-// ##1. BannerItem 인터페이스 정의
-interface BannerItem {
-  text: string
-  icon: string
-  alt: string
-}
-// ##2. Banner 컴포넌트
-const Banner = ({
-  items,
-  direction,
-}: {
-  items: BannerItem[]
-  direction: 'left' | 'right'
-}) => {
-  return (
-    <div className={`banner_line ${direction}`}>
-      <div className="roller_wrap">
-        <div className="rolling_list">
-          {items.map((item, index) => (
-            <div key={`${direction}-${index}`}>
-              <p>{item.text}</p>
-              <img src={item.icon} alt={item.alt} />
-            </div>
-          ))}
-        </div>
-      </div>
-    </div>
-  )
-}
-// ##3. BannerItem 배열 선언
-const bannerItemsList: BannerItem[] = [
-  { text: 'LET’S LOOK FOR A GAME!', icon: icon1, alt: '아이콘1' },
-  { text: 'LET’S LOOK FOR A GAME!', icon: icon2, alt: '아이콘2' },
-  { text: 'LET’S LOOK FOR A GAME!', icon: icon3, alt: '아이콘3' },
-]
-
 export const Main = () => {
-  const [overlapItems, setOverlapItems] = useState<BannerItem[]>([])
-
-  useEffect(() => {
-    // ##4. 아이템 복제
-    setOverlapItems([...bannerItemsList, ...bannerItemsList])
-  }, [])
-
-  useEffect(() => {
-    // ##5. overlapItems가 업데이트된 후 복제 수행
-    if (overlapItems.length > 0) {
-      const rollers = document.querySelectorAll<HTMLDivElement>('.roller_wrap')
-      rollers.forEach((roller, index) => {
-        const rollingList =
-          roller.querySelector<HTMLDivElement>('.rolling_list')
-        if (rollingList) {
-          const clone = rollingList.cloneNode(true) as HTMLDivElement
-          clone.id = `roller${index + 1}_clone`
-          roller.appendChild(clone)
-          rollingList.classList.add('original')
-          clone.classList.add('clone')
-        }
-      })
-    }
-  }, [overlapItems]) // overlapItems가 변경될 때 실행
-
-  //--------------- 현재 날짜/시간 구하기 ---------------//
-  useEffect(() => {
-    // ##1. 날짜 및 시간 설정
-    const updateDateTime = () => {
-      const today = new Date()
-
-      // ##1-1. 날짜 구하기
-      const year = today.getFullYear()
-      const month = String(today.getMonth() + 1).padStart(2, '0')
-      const day = String(today.getDate()).padStart(2, '0')
-
-      const todayText = document.querySelector<HTMLDivElement>('.today')
-      if (todayText) {
-        todayText.textContent = `${month}/${day}/${year}`
-      }
-      // ##1-2. 시간 구하기
-      const hours = String(today.getHours()).padStart(2, '0')
-      const minutes = String(today.getMinutes()).padStart(2, '0')
-      const seconds = String(today.getSeconds()).padStart(2, '0')
-
-      const todayTimeText = document.querySelector<HTMLDivElement>('.time')
-      if (todayTimeText) {
-        todayTimeText.textContent = `${hours}:${minutes}:${seconds}`
-      }
-    }
-
-    updateDateTime()
-    const getClock = setInterval(updateDateTime, 1000)
-
-    return () => clearInterval(getClock)
-  }, [])
+  const [overlapItems] = useState(bannerItemsList.concat(bannerItemsList))
 
   return (
     <main className="main">
       <section className="sc_hero">
         {/* 상단 배너 */}
-        <Banner items={overlapItems} direction="left" />
+        <RollingBanner items={overlapItems} direction="left" />
 
         {/* 가운데 콘텐츠 */}
         <div className="inner">
@@ -120,28 +26,21 @@ export const Main = () => {
                 <p data-child="GAME">GAME</p>
                 <p data-child="FESTIVAL">FESTIVAL</p>
               </h1>
-              <div className="getDate">
-                <p className="today"></p>
-                <p className="time"></p>
-              </div>
+              <CurrentTime />
               <div className="star"></div>
             </div>
           </div>
           <div className="right_column">
-            <div>
-              <img src={window1} alt="데코1" />
-            </div>
-            <div>
-              <img src={window2} alt="데코2" />
-            </div>
-            <div>
-              <img src={window3} alt="데코3" />
-            </div>
+            {[window1, window2, window3].map((el, idx) => (
+              <div>
+                <img src={el} alt={`데코${idx}`} />
+              </div>
+            ))}
           </div>
         </div>
 
         {/* 하단 배너 */}
-        <Banner items={overlapItems} direction="right" />
+        <RollingBanner items={overlapItems} direction="right" />
       </section>
     </main>
   )

--- a/src/domains/main/constants/bannerItemsList.ts
+++ b/src/domains/main/constants/bannerItemsList.ts
@@ -1,0 +1,9 @@
+import icon1 from '@/assets/imgs/main/img_hero_icon1.png'
+import icon2 from '@/assets/imgs/main/img_hero_icon2.png'
+import icon3 from '@/assets/imgs/main/img_hero_icon3.png'
+
+export const bannerItemsList = [
+  { text: 'LET’S LOOK FOR A GAME!', icon: icon1 },
+  { text: 'LET’S LOOK FOR A GAME!', icon: icon2 },
+  { text: 'LET’S LOOK FOR A GAME!', icon: icon3 },
+]

--- a/src/domains/main/constants/index.ts
+++ b/src/domains/main/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './bannerItemsList'


### PR DESCRIPTION
기존
-useEffect 내부에서 돔조작 API를 통해 롤링 배너를 클론하고 별도의 class와 id를 할당
-현재 시간 관련 로직이 페이지 컴포넌트 내에 함께 작성되어 초 단위로 전체 컴포넌트가 재 선언 됨

리팩토링 후
-동적으로 할당되는 id를 배열로 만들어 렌더링 시점에 롤링 배너 클론까지 생성
-현재 시간 영역을 컴포넌트로 분리하여 렌더링 범위 축소 및 유지보수성 향상
-일부 타입 명칭 컨벤션에 맞게 수정

---

아마 한 파일 안에서 모든 로직과 데이터를 관리하는 방식이 더 익숙하실 것 같습니다.
그래서 영역별로 컴포넌트를 분리하고 데이터를 다른 파일로 나눈 점이 복잡하고 굳이? 싶으실 수도 있을 것 같아요.
그런데 리액트에서는 로직, 데이터, UI를 컴포넌트와 별도 파일로 분리해 관리하는 패턴이 권장 된다고 합니다.
(물론 너무 작은 단위까지 쪼갤 필요는 저도 없어보입니다.)
이 방식의 장점으로는 역할별로 컴포넌트가 분리되어 유지보수가 수월해지고 독립성이 보장되며, 관계없는 바깥 영역까지 렌더링 시키지 않아 성능적으로도 유리하다고 하네요. 
물론 권장사항인 만큼 익숙치 않으시다면 우선 편하신 방식으로 작업해 주셔도 무방합니다! 

이해가 어렵거나 개선이 필요한 부분이 보이시면 언제든 의견 주시면 감사드리겠습니다~! 😊